### PR TITLE
Abstract locator common interface

### DIFF
--- a/src/main/java/com/servicewizard/Main.java
+++ b/src/main/java/com/servicewizard/Main.java
@@ -19,6 +19,10 @@ public class Main {
 		String moduleName = args[2];
 		String urlBase = args[3];
 
+		if (!outputRoot.exists()) {
+			outputRoot.mkdirs();
+		}
+
 		List<Service> services = new JerseyResourceLocator(scanPackage).locate();
 		
 		for (Transformer transformer : new Transformer[] {

--- a/src/main/java/com/servicewizard/Main.java
+++ b/src/main/java/com/servicewizard/Main.java
@@ -1,28 +1,31 @@
 
 package com.servicewizard;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
 import com.servicewizard.locator.JerseyResourceLocator;
 import com.servicewizard.model.Service;
 import com.servicewizard.transformer.AngularServiceTransformer;
 import com.servicewizard.transformer.MarkdownTransformer;
-
-import java.util.List;
+import com.servicewizard.transformer.Transformer;
 
 public class Main {
 
-	public static void main(String... args) {
+	public static void main(String... args) throws IOException {
 		String scanPackage = args[0];
-		String outputPath = args[1];
+		File outputRoot = new File(args[1]);
 		String moduleName = args[2];
 		String urlBase = args[3];
 
 		List<Service> services = new JerseyResourceLocator(scanPackage).locate();
-
-		new MarkdownTransformer().transform(services, outputPath + "/api-documentation.md");
-
-		for (Service service : services) {
-			String serviceOutput = outputPath + "/" + service.getName() + ".js";
-			new AngularServiceTransformer().transform(moduleName, urlBase, service, serviceOutput);
+		
+		for (Transformer transformer : new Transformer[] {
+				new MarkdownTransformer(),
+				new AngularServiceTransformer()
+			}) {
+			transformer.transform(moduleName, urlBase, services, outputRoot);
 		}
 	}
 }

--- a/src/main/java/com/servicewizard/transformer/MarkdownTransformer.java
+++ b/src/main/java/com/servicewizard/transformer/MarkdownTransformer.java
@@ -1,31 +1,21 @@
 
 package com.servicewizard.transformer;
 
-import com.servicewizard.model.Service;
-import com.servicewizard.model.ServiceMethod;
-
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class MarkdownTransformer {
+import com.servicewizard.model.Service;
+import com.servicewizard.model.ServiceMethod;
 
-	public void transform(List<Service> services) {
-		try {
-			transform(services, System.out);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
+public class MarkdownTransformer implements Transformer {
 
-	public void transform(List<Service> services, String fileName) {
-		try {
-			PrintStream fileWriter = new PrintStream(fileName);
-			transform(services, fileWriter);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+	@Override
+	public void transform(String moduleName, String urlBase, List<Service> services, File outputRoot) throws IOException {
+		transform(services, new PrintStream(
+				new File(outputRoot, "api-documentation.md")));
 	}
 
 	private void transform(List<Service> services, PrintStream output) throws IOException {

--- a/src/main/java/com/servicewizard/transformer/Transformer.java
+++ b/src/main/java/com/servicewizard/transformer/Transformer.java
@@ -1,0 +1,20 @@
+package com.servicewizard.transformer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import com.servicewizard.model.Service;
+
+public interface Transformer {
+	/**
+	 * Transform the service model into a specific format.
+	 * 
+	 * @param moduleName The name of the module to build (if applicable).
+	 * @param urlBase The base URL at which the described API will be running.
+	 * @param services The service model.
+	 * @param outputRoot The root output directory to build into.
+	 * @throws IOException If an exception occurs writing the output files.
+	 */
+	public void transform(String moduleName, String urlBase, List<Service> services, File outputRoot) throws IOException;
+}

--- a/src/main/java/com/servicewizard/transformer/formatting/Indentation.java
+++ b/src/main/java/com/servicewizard/transformer/formatting/Indentation.java
@@ -3,7 +3,7 @@ package com.servicewizard.transformer.formatting;
 
 public class Indentation implements AutoCloseable {
 
-	public void close() throws Exception {
+	public void close() {
 		indentingStream.unindent();
 	}
 


### PR DESCRIPTION
- Moved from filenames + path-building to `File` usage for better cross-OS support.
- Removed some stack trace printing - if there's an IOException during the output flow, it's _all_ going to fail - that's either going to be an issue of disk space or permissions. Not recoverable.
- Removed `throws Exception` from `Indentation.close` as it isn't necessary and mucked up the code a little (see http://docs.oracle.com/javase/7/docs/api/java/lang/AutoCloseable.html)
